### PR TITLE
fix(listAtom): update the inner fieldAtom's `name` with current list name & position (#109)

### DIFF
--- a/src/atoms/extendFieldAtom.ts
+++ b/src/atoms/extendFieldAtom.ts
@@ -1,5 +1,5 @@
 import { FieldAtom } from "form-atoms";
-import { Atom, atom } from "jotai";
+import { Atom, Getter, atom } from "jotai";
 
 export type ExtendFieldAtom<Value, State> =
   FieldAtom<Value> extends Atom<infer DefaultState>
@@ -7,16 +7,28 @@ export type ExtendFieldAtom<Value, State> =
     : never;
 
 export const extendFieldAtom = <
-  T extends FieldAtom<any>,
+  T extends Atom<any>,
   E extends Record<string, unknown>,
 >(
   field: T,
-  makeAtoms: (cfg: T extends Atom<infer Config> ? Config : never) => E,
+  makeAtoms: (
+    cfg: T extends Atom<infer Config> ? Config : never,
+    get: Getter,
+  ) => E,
 ) =>
-  atom((get) => {
-    const base = get(field);
-    return {
-      ...base,
-      ...makeAtoms(base as T extends Atom<infer Config> ? Config : never),
-    };
-  });
+  atom(
+    (get) => {
+      const base = get(field);
+      return {
+        ...base,
+        ...makeAtoms(
+          base as T extends Atom<infer Config> ? Config : never,
+          get,
+        ),
+      };
+    },
+    (get, set, update: T extends Atom<infer Config> ? Config : never) => {
+      // @ts-expect-error fieldAtom is PrimitiveAtom
+      set(field, { ...get(field), ...update });
+    },
+  );

--- a/src/atoms/list-atom/listItemForm.ts
+++ b/src/atoms/list-atom/listItemForm.ts
@@ -1,0 +1,201 @@
+import {
+  FormAtom,
+  FormFieldErrors,
+  FormFieldValues,
+  FormFields,
+  RESET,
+  SubmitStatus,
+  TouchedFields,
+  ValidateOn,
+  ValidateStatus,
+  formAtom,
+  walkFields,
+} from "form-atoms";
+import {
+  Atom,
+  Getter,
+  SetStateAction,
+  Setter,
+  WritableAtom,
+  atom,
+} from "jotai";
+import { atomEffect } from "jotai-effect";
+
+import { ListAtomItems } from "./listBuilder";
+import { extendFieldAtom } from "../extendFieldAtom";
+
+export type ExtendFormAtom<Fields extends FormFields, State> =
+  FormAtom<Fields> extends Atom<infer DefaultState>
+    ? Atom<DefaultState & State>
+    : never;
+
+// TODO(types): ExtendFormAtom does not work
+// The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed.
+type NamedFormAtom<Fields extends FormFields> = Atom<{
+  nameAtom: Atom<string>;
+
+  /**
+   * An atom containing an object of nested field atoms
+   */
+  fields: WritableAtom<
+    Fields,
+    [Fields | typeof RESET | ((prev: Fields) => Fields)],
+    void
+  >;
+  /**
+   * An read-only atom that derives the form's values from
+   * its nested field atoms.
+   */
+  values: Atom<FormFieldValues<Fields>>;
+  /**
+   * An read-only atom that derives the form's errors from
+   * its nested field atoms.
+   */
+  errors: Atom<FormFieldErrors<Fields>>;
+  /**
+   * A read-only atom that returns `true` if any of the fields in
+   * the form are dirty.
+   */
+  dirty: Atom<boolean>;
+  /**
+   * A read-only atom derives the touched state of its nested field atoms.
+   */
+  touchedFields: Atom<TouchedFields<Fields>>;
+  /**
+   * A write-only atom that resets the form's nested field atoms
+   */
+  reset: WritableAtom<null, [], void>;
+  /**
+   * A write-only atom that validates the form's nested field atoms
+   */
+  validate: WritableAtom<null, [] | [ValidateOn], void>;
+  /**
+   * A read-only atom that derives the form's validation status
+   */
+  validateStatus: Atom<ValidateStatus>;
+  /**
+   * A write-only atom for submitting the form
+   */
+  submit: WritableAtom<
+    null,
+    [(value: FormFieldValues<Fields>) => void | Promise<void>],
+    void
+  >;
+  /**
+   * A read-only atom that reads the number of times the form has
+   * been submitted
+   */
+  submitCount: Atom<number>;
+  /**
+   * An atom that contains the form's submission status
+   */
+  submitStatus: WritableAtom<SubmitStatus, [SubmitStatus], void>;
+  _validateFields: (
+    get: Getter,
+    set: Setter,
+    event: ValidateOn,
+  ) => Promise<void>;
+}>;
+
+export type ListItemForm<Fields extends ListAtomItems> = NamedFormAtom<{
+  fields: Fields;
+}>;
+
+// export type ListItemForm<Fields extends ListAtomItems> = ExtendFormAtom<
+//   {
+//     fields: Fields;
+//   },
+//   {
+//     nameAtom: Atom<string>;
+//   }
+// >;
+
+export function listItemForm<Fields extends ListAtomItems>({
+  fields,
+  formListAtom,
+  getListNameAtom,
+}: {
+  /**
+   * The fields of the item form.
+   */
+  fields: Fields;
+  /**
+   * The atom where this list item will be stored.
+   */
+  formListAtom: WritableAtom<
+    ListItemForm<Fields>[],
+    [typeof RESET | SetStateAction<ListItemForm<Fields>[]>],
+    void
+  >;
+  /**
+   * The nameAtom of the parent listAtom.
+   */
+  getListNameAtom: (
+    get: Getter,
+  ) =>
+    | Atom<string>
+    | WritableAtom<
+        string | undefined,
+        [string | undefined | typeof RESET],
+        void
+      >;
+}) {
+  const itemFormAtom: ListItemForm<Fields> = extendFieldAtom(
+    formAtom({ fields }),
+    (base, get) => {
+      console.log("building itemFormAtom");
+      const nameAtom = atom((get) => {
+        const list: ListItemForm<Fields>[] = get(formListAtom);
+        const listName = get(getListNameAtom(get));
+
+        return `${listName ?? ""}[${list.indexOf(itemFormAtom)}]`;
+      });
+
+      const patchNamesEffect = atomEffect((get, set) => {
+        const fields = get(base.fields);
+
+        console.log("runs effect");
+
+        walkFields(fields, (field) => {
+          const { name: originalFieldNameAtom } = get(field);
+
+          const scopedNameAtom = atom(
+            (get) => {
+              return [get(nameAtom), get(originalFieldNameAtom)]
+                .filter(Boolean)
+                .join(".");
+            },
+            (_, set, update: string) => {
+              set(originalFieldNameAtom, update);
+            },
+          );
+
+          // @ts-expect-error field is PrimitiveAtom
+          set(field, { name: scopedNameAtom, originalFieldNameAtom });
+        });
+
+        return () => {
+          walkFields(fields, (field) => {
+            // @ts-expect-error oh yes
+            const { originalFieldNameAtom } = get(field);
+
+            // @ts-expect-error field is PrimitiveAtom
+            set(field, {
+              // drop the scopedNameAtom, as to not make it original on next mount
+              name: originalFieldNameAtom,
+              originalFieldNameAtom: undefined,
+            });
+          });
+        };
+      });
+
+      get(patchNamesEffect); // subscribe
+
+      return {
+        name: nameAtom,
+      };
+    },
+  );
+
+  return itemFormAtom;
+}

--- a/src/components/list/Docs.mdx
+++ b/src/components/list/Docs.mdx
@@ -19,6 +19,7 @@ import { List } from "@form-atoms/field";
 - ✅ Handles **adding, removal and ordering** of the list items with custom render props.
 - ✅ **Blank Slate ready**. Can render a custom `<Empty />` component via render prop when the list is empty.
 - ✅ **Reorder items** with pre-configured **`moveUp` & `moveDown` actions.**
+- ✅ Scoped field `name` attribute with dynamic index position.
 - ✅ Supports **nested lists in lists**.
 
 ## Props

--- a/src/components/list/List.stories.tsx
+++ b/src/components/list/List.stories.tsx
@@ -9,6 +9,7 @@ import {
   listField,
   textField,
 } from "../../fields";
+import { PicoFieldName } from "../../scenarios/PicoFieldName";
 import { StoryForm } from "../../scenarios/StoryForm";
 import { FieldLabel } from "../field-label";
 
@@ -67,6 +68,7 @@ export const ListOfObjects = listStory({
   },
   args: {
     field: listField({
+      name: "environment",
       value: [
         { variable: "GITHUB_TOKEN", value: "ff52d09a" },
         { variable: "NPM_TOKEN", value: "deepsecret" },
@@ -84,15 +86,25 @@ export const ListOfObjects = listStory({
           gridTemplateColumns: "auto auto min-content",
         }}
       >
-        <InputField
-          atom={fields.variable}
-          render={(props) => <input {...props} placeholder="Variable Name" />}
-        />
-        <InputField
-          atom={fields.value}
-          render={(props) => <input {...props} placeholder="Variable Value" />}
-        />
-        <RemoveButton />
+        <div>
+          <InputField
+            atom={fields.variable}
+            render={(props) => <input {...props} placeholder="Variable Name" />}
+          />
+          <PicoFieldName field={fields.variable} />
+        </div>
+        <div>
+          <InputField
+            atom={fields.value}
+            render={(props) => (
+              <input {...props} placeholder="Variable Value" />
+            )}
+          />
+          <PicoFieldName field={fields.variable} />
+        </div>
+        <div>
+          <RemoveButton />
+        </div>
       </div>
     ),
   },
@@ -109,6 +121,7 @@ export const ListOfPrimitiveValues = listStory({
   },
   args: {
     field: listField({
+      name: "productReview",
       value: ["quality materials used", "not so heavy"],
       builder: (value) => textField({ value }),
     }),
@@ -130,6 +143,7 @@ export const ListOfPrimitiveValues = listStory({
 type ListFields<T> = T extends TListField<infer Fields, any> ? Fields : never;
 
 const productPros = listField({
+  name: "productReview",
   value: ["quality materials used", "not so heavy"],
   builder: (value) => textField({ value }),
 });
@@ -298,12 +312,14 @@ export const NestedList = listStory({
         },
       ],
       builder: ({ name, lastName, accounts = [] }) => ({
-        name: textField({ value: name }),
-        lastName: textField({ value: lastName }),
+        name: textField({ value: name, name: "name" }),
+        lastName: textField({ value: lastName, name: "lastName" }),
         accounts: listField({
           name: "accounts",
           value: accounts,
-          builder: ({ iban }) => ({ iban: textField({ value: iban }) }),
+          builder: ({ iban }) => ({
+            iban: textField({ value: iban, name: "iban" }),
+          }),
         }),
       }),
     }),

--- a/src/fields/list-field/listField.ts
+++ b/src/fields/list-field/listField.ts
@@ -89,7 +89,7 @@ export const listField = <
     const optionalZodFieldAtom = extendFieldAtom(
       listAtom({ ...config, validate }),
       () => ({ required: requiredAtom }),
-    ) as OptionalListField<Fields>;
+    ) as unknown as OptionalListField<Fields>;
 
     optionalZodFieldAtom.optional = () => optionalZodFieldAtom;
 

--- a/src/fields/zod-field/zodField.ts
+++ b/src/fields/zod-field/zodField.ts
@@ -14,7 +14,7 @@ export type ZodFieldConfig<
   Schema extends z.Schema,
   OptSchema extends z.Schema = ZodUndefined,
 > = FieldAtomConfig<Schema["_output"] | OptSchema["_output"]> &
-  ValidateConfig<Schema, OptSchema>;
+  ValidateConfig<Schema, OptSchema> & { nameAtom?: Atom<string> };
 
 export type ZodFieldValue<Field> =
   Field extends FieldAtom<infer Value> ? Value : never;
@@ -57,7 +57,12 @@ export type ZodField<
 export function zodField<
   Schema extends z.Schema,
   OptSchema extends z.Schema = ZodUndefined,
->({ schema, optionalSchema, ...config }: ZodFieldConfig<Schema, OptSchema>) {
+>({
+  schema,
+  optionalSchema,
+  nameAtom,
+  ...config
+}: ZodFieldConfig<Schema, OptSchema>) {
   const { validate, requiredAtom, makeOptional } = schemaValidate({
     schema,
     optionalSchema,
@@ -67,6 +72,7 @@ export function zodField<
     fieldAtom({ ...config, validate }),
     () => ({
       required: requiredAtom,
+      ...(nameAtom ? { name: nameAtom } : {}),
     }),
   ) as unknown as RequiredZodField<Schema, OptSchema>;
 
@@ -75,8 +81,11 @@ export function zodField<
 
     const optionalZodFieldAtom = extendFieldAtom(
       fieldAtom({ ...config, validate }),
-      () => ({ required: requiredAtom }),
-    ) as OptionalZodField<Schema, OptSchema>;
+      () => ({
+        required: requiredAtom,
+        ...(nameAtom ? { name: nameAtom } : {}),
+      }),
+    ) as unknown as OptionalZodField<Schema, OptSchema>;
 
     optionalZodFieldAtom.optional = () => optionalZodFieldAtom;
 

--- a/src/hooks/use-list-actions/useListActions.ts
+++ b/src/hooks/use-list-actions/useListActions.ts
@@ -1,4 +1,4 @@
-import { UseFieldOptions, formAtom } from "form-atoms";
+import { UseFieldOptions } from "form-atoms";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useTransition } from "react";
 
@@ -8,6 +8,7 @@ import {
   ListAtomValue,
   ListItem,
 } from "../../atoms/list-atom";
+import { listItemForm } from "../../atoms/list-atom/listItemForm";
 
 export const useListActions = <
   Fields extends ListAtomItems,
@@ -31,7 +32,13 @@ export const useListActions = <
   const add = useCallback((before?: ListItem<Fields>, fields?: Fields) => {
     dispatchSplitList({
       type: "insert",
-      value: fields ? formAtom({ fields }) : atoms.buildItem(),
+      value: fields
+        ? listItemForm({
+            fields,
+            getListNameAtom: (get) => get(list).name,
+            formListAtom: atoms._formList,
+          })
+        : atoms.buildItem(),
       before,
     });
     startTransition(() => {

--- a/src/scenarios/PicoFieldName.tsx
+++ b/src/scenarios/PicoFieldName.tsx
@@ -1,0 +1,15 @@
+import { FieldAtom } from "form-atoms";
+import { useAtomValue } from "jotai";
+
+const useFieldName = (fieldAtom: FieldAtom<any>) =>
+  useAtomValue(useAtomValue(fieldAtom).name);
+
+export const PicoFieldName = ({ field }: { field: FieldAtom<any> }) => {
+  const name = useFieldName(field);
+
+  return (
+    <small>
+      My name is <code>{name}</code>
+    </small>
+  );
+};

--- a/src/scenarios/dependent-validation/PasswordValidation.stories.tsx
+++ b/src/scenarios/dependent-validation/PasswordValidation.stories.tsx
@@ -22,8 +22,6 @@ const confirmPassword = textField({
     (get) => {
       const initialPassword = get(get(password).value);
 
-      console.log("hm");
-
       return z.literal(initialPassword);
     },
     {


### PR DESCRIPTION
Fixes #109 

* test(listAtom): scoped names

* listItem as extended formAtom with name

* use extended listItemForm

* fix types so build passes

* add effect for syncing field names

* docs(List): add names

* test(listAtom): the indexes are updated for current values

* docs: add feature for scoped names

* fix compouning names, drop the scoped atom once the fields unmount.